### PR TITLE
Add feature to allow routines

### DIFF
--- a/src/common/database/models/Link.js
+++ b/src/common/database/models/Link.js
@@ -10,11 +10,13 @@ const LinkSchema = new Schema(
     },
     url: {
       type: String,
-      required: true,
     },
     owner: {
       type: Schema.Types.ObjectId,
       ref: 'User',
+    },
+    routine: {
+      type: String,
     },
     isPrivate: {
       type: Boolean,

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,8 +4,8 @@ module.exports = [
   {
     method: 'GET',
     path: '/',
-    handler: (request, h) => {
-      return h.redirect(config.goLinksAdminUrl);
+    handler: (request, reply) => {
+      return reply.redirect(config.goLinksAdminUrl);
     },
     config: {
       tags: ['api', 'links'],

--- a/src/services/links/handlers/redirect.js
+++ b/src/services/links/handlers/redirect.js
@@ -4,7 +4,7 @@ const methods = require('../methods');
 
 const { to } = helpers.functionalHelpers;
 
-module.exports = async ({ logger, params }, h) => {
+module.exports = async ({ logger, params }, reply) => {
   const [error, res] = await to(methods.redirect(params));
 
   if (error) {
@@ -16,5 +16,15 @@ module.exports = async ({ logger, params }, h) => {
     return res.error();
   }
 
-  return h.redirect(res.link.url);
+  // We have 2 types of links.
+  // Routines: Execute some piece of code that handles all the logic.
+  //      It's like an action instead of a simple redirect
+  // normal: Simple redirect. Match the given name with an url
+  //      and redirect to it
+  if (res.link.routine) {
+    //TODO(luis) support parameters? Needs extra security
+    return methods.execRoutine(res.link.routine, params, reply);
+  }
+
+  return reply.redirect(res.link.url);
 };

--- a/src/services/links/methods/execRoutine.js
+++ b/src/services/links/methods/execRoutine.js
@@ -1,0 +1,12 @@
+const routines = require('../routines');
+const { notFound } = require('@hapi/boom');
+
+module.exports = (routineName, params, reply) => {
+  const targetRoutine = routines[routineName];
+
+  if (!targetRoutine) {
+    throw notFound(`${routineName} routine not found`);
+  }
+
+  return targetRoutine(params, reply);
+}

--- a/src/services/links/methods/index.js
+++ b/src/services/links/methods/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  execRoutine: require('./execRoutine'),
   getLinks: require('./getLinks'),
   redirect: require('./redirect'),
   store: require('./store'),

--- a/src/services/links/routines/estudioCelula.js
+++ b/src/services/links/routines/estudioCelula.js
@@ -1,0 +1,3 @@
+module.exports = (params, reply) => {
+  return reply.redirect('https://castillodelreybrisas.com/celulas');
+}

--- a/src/services/links/routines/index.js
+++ b/src/services/links/routines/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  estudioCelula: require('./estudioCelula'),
+  testRoutine: require('./testRoutine'),
+}

--- a/src/services/links/routines/testRoutine.js
+++ b/src/services/links/routines/testRoutine.js
@@ -1,0 +1,3 @@
+module.exports = async (params, reply) => {
+  return reply.redirect('https://test.com');
+}

--- a/test/services/links/routes.spec.js
+++ b/test/services/links/routes.spec.js
@@ -4,7 +4,10 @@ const sinon = require('sinon');
 
 const methods = require('../../../src/services/links/methods');
 const { db, utils, testServer } = require('../../testCommon');
-const factories = require('../../testCommon/factories');
+const {
+  factories,
+  prefabs,
+} = db;
 
 const { initDatabase } = db;
 
@@ -126,6 +129,7 @@ describe('#links routes', function () {
   describe('GET /', function () {
     let route;
     let testLink;
+    let testRoutine;
 
     before(async function () {
       await initDatabase();
@@ -137,6 +141,7 @@ describe('#links routes', function () {
 
       // Create test links
       testLink = await factories.Link.create();
+      testRoutine = await prefabs.Link.createRoutine();
     });
 
     describe('logic', function() {
@@ -149,6 +154,12 @@ describe('#links routes', function () {
         const res = await serverInject(route(testLink.name), {});
         expect(res.statusCode).to.equal(302);
         expect(res.headers.location).to.equal(testLink.url);
+      });
+
+      it('should run routine', async function() {
+        const res = await serverInject(route(testRoutine.name), {});
+        expect(res.statusCode).to.equal(302);
+        expect(res.headers.location).to.equal('https://test.com');
       });
     });
   });

--- a/test/testCommon/prefabs/Link.js
+++ b/test/testCommon/prefabs/Link.js
@@ -1,0 +1,8 @@
+module.exports = (factories) => ({
+  createRoutine() {
+    return factories.Link.create({
+      name: 'myroutine',
+      routine: 'testRoutine',
+    })
+  }
+})


### PR DESCRIPTION
## Background
Routines are actions triggers when a link matches a link. This allows extended functionality, like parsing an HTML and getting a resource, or generate the a redirect link based on ever-changing params like time (like getting daily reports, etc)

## What does this PR do?

